### PR TITLE
Avoid `MaybeUninit` and `array_map` so that we can compile on Rust stable

### DIFF
--- a/src/operand.rs
+++ b/src/operand.rs
@@ -152,7 +152,7 @@ impl TryFrom<&bad64_sys::InstructionOperand> for Operand {
             OperandClass::SYS_REG => Ok(Self::SysReg(SysReg::from_u32(oo.sysreg as u32).unwrap())),
             OperandClass::MEM_REG => Ok(Self::MemReg(Reg::from_u32(oo.reg[0] as u32).unwrap())),
             OperandClass::STR_IMM => Ok(Self::StrImm {
-                str: oo.name.map(|x| x as u8),
+                str: unsafe { ::core::mem::transmute(oo.name) },
                 imm: oo.immediate,
             }),
             OperandClass::MEM_OFFSET => Ok(Self::MemOffset {
@@ -193,7 +193,7 @@ impl TryFrom<&bad64_sys::InstructionOperand> for Operand {
                 o2: oo.implspec[4],
             }),
             OperandClass::CONDITION => Ok(Self::Cond(Condition::from_u32(oo.cond as u32).unwrap())),
-            OperandClass::NAME => Ok(Self::Name(oo.name.map(|x| x as u8))),
+            OperandClass::NAME => Ok(Self::Name(unsafe { ::core::mem::transmute(oo.name) })),
             OperandClass::NONE => Err(()),
         }
     }


### PR DESCRIPTION
Thanks for a great project. This is exactly what I need! However, I need a version that builds on Rust stable. Attempting to build on stable gives the following errors:

```
$ cargo check
[... lines omitted ...]
    Checking bad64 v0.2.0 (/home/apt1002/temp/bad64)
error[E0554]: `#![feature]` may not be used on the stable release channel
  --> src/lib.rs:67:1
   |
67 | #![feature(maybe_uninit_uninit_array, maybe_uninit_extra, maybe_uninit_slice)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0554]: `#![feature]` may not be used on the stable release channel
  --> src/lib.rs:68:1
   |
68 | #![feature(array_map)]
   | ^^^^^^^^^^^^^^^^^^^^^^
```

These problems are pretty easy to fix. It is sufficient to initialise some variables and find an alternative to `array_map`. You might not like all my choices in this pull request; they are only intended to show that the fix is easy.

Yours hopefully,

- Alistair