### PR TITLE
build with stable rust

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
       - name: Build
         run: cargo build --verbose
       - name: Run tests

--- a/src/operand.rs
+++ b/src/operand.rs
@@ -101,6 +101,8 @@ pub enum Operand {
         str: [u8; MAX_NAME as usize],
         imm: u64,
     },
+    /// This is a special enumerated type for the Rust bindings
+    None,
 }
 
 #[allow(non_upper_case_globals)]
@@ -152,7 +154,7 @@ impl TryFrom<&bad64_sys::InstructionOperand> for Operand {
             OperandClass::SYS_REG => Ok(Self::SysReg(SysReg::from_u32(oo.sysreg as u32).unwrap())),
             OperandClass::MEM_REG => Ok(Self::MemReg(Reg::from_u32(oo.reg[0] as u32).unwrap())),
             OperandClass::STR_IMM => Ok(Self::StrImm {
-                str: oo.name.map(|x| x as u8),
+                str: unsafe { core::mem::transmute(oo.name) },
                 imm: oo.immediate,
             }),
             OperandClass::MEM_OFFSET => Ok(Self::MemOffset {
@@ -193,7 +195,7 @@ impl TryFrom<&bad64_sys::InstructionOperand> for Operand {
                 o2: oo.implspec[4],
             }),
             OperandClass::CONDITION => Ok(Self::Cond(Condition::from_u32(oo.cond as u32).unwrap())),
-            OperandClass::NAME => Ok(Self::Name(oo.name.map(|x| x as u8))),
+            OperandClass::NAME => Ok(Self::Name(unsafe { core::mem::transmute(oo.name) })),
             OperandClass::NONE => Err(()),
         }
     }
@@ -317,6 +319,10 @@ impl fmt::Display for Operand {
 
                 write!(f, "{} #{:#x}", name, imm)
             }
+            Self::None => write!(
+                f,
+                "None (This is an internal type for the rust-bindings, and most likely an error)"
+            ),
         }
     }
 }


### PR DESCRIPTION
So a wonderful person wrote an AARCH64 lifter for Falcon against these bindings :)! https://github.com/kawadakk/falcon/tree/aarch64-bad64

I want to bring these bindings into Falcon (we're working it https://github.com/falconre/falcon/pull/108). In order for that to happen those bindings are going to need to build stable, which means bad64 will need to build stable.

This PR is a proposal to make bad64 build stable. It's probably slightly slower than the original. Very open to comments. Let me know.