### PR TITLE
Add exhaustive decoding example

### DIFF
--- a/examples/exhaustive.rs
+++ b/examples/exhaustive.rs
@@ -1,0 +1,22 @@
+fn main() {
+    let start = std::time::Instant::now();
+    let mut decoded = 0;
+
+    for int in 0..=u32::MAX {
+        let inst = bad64::decode(int, 0);
+
+        if inst.is_ok() {
+            decoded += 1;
+        }
+
+        if (int > 0) && (int & 0x07ff_ffff == 0) {
+            let time = start.elapsed();
+            let p = (int as f64) / (u32::MAX as f64) * 100.0;
+            let rate = (int as f64) / u64::max(1, time.as_secs()) as f64;
+            println!("checked {} words ({:.1}%) in {:.1?} ({:.0} words/sec)", int, p, time, rate);
+        }
+    }
+
+    let time = start.elapsed();
+    println!("decoded {} valid instructions in {:.1?}", decoded, time);
+}


### PR DESCRIPTION
This panics on `main` right now, but run to completion, looks like:
```
checked 134217728 words (3.1%) in 7.7s (19173961 words/sec)
checked 268435456 words (6.3%) in 17.1s (15790321 words/sec)
checked 402653184 words (9.4%) in 28.8s (14380471 words/sec)
checked 536870912 words (12.5%) in 38.9s (14128182 words/sec)
checked 671088640 words (15.6%) in 46.8s (14588883 words/sec)
checked 805306368 words (18.8%) in 59.6s (13649260 words/sec)
checked 939524096 words (21.9%) in 71.9s (13232734 words/sec)
checked 1073741824 words (25.0%) in 82.1s (13094412 words/sec)
checked 1207959552 words (28.1%) in 89.8s (13572579 words/sec)
checked 1342177280 words (31.3%) in 99.6s (13557346 words/sec)
checked 1476395008 words (34.4%) in 108.8s (13670324 words/sec)
checked 1610612736 words (37.5%) in 118.2s (13649260 words/sec)
checked 1744830464 words (40.6%) in 126.1s (13847861 words/sec)
checked 1879048192 words (43.8%) in 138.6s (13616291 words/sec)
checked 2013265920 words (46.9%) in 147.3s (13695687 words/sec)
checked 2147483648 words (50.0%) in 157.1s (13678240 words/sec)
checked 2281701376 words (53.1%) in 165.4s (13828493 words/sec)
checked 2415919104 words (56.3%) in 174.7s (13884593 words/sec)
checked 2550136832 words (59.4%) in 187.5s (13637095 words/sec)
checked 2684354560 words (62.5%) in 197.2s (13626165 words/sec)
checked 2818572288 words (65.6%) in 205.4s (13749133 words/sec)
checked 2952790016 words (68.8%) in 218.2s (13544908 words/sec)
checked 3087007744 words (71.9%) in 231.0s (13421773 words/sec)
checked 3221225472 words (75.0%) in 240.1s (13421773 words/sec)
checked 3355443200 words (78.1%) in 248.6s (13530013 words/sec)
checked 3489660928 words (81.3%) in 258.4s (13525818 words/sec)
checked 3623878656 words (84.4%) in 268.8s (13521935 words/sec)
checked 3758096384 words (87.5%) in 277.4s (13567135 words/sec)
checked 3892314112 words (90.6%) in 285.6s (13657242 words/sec)
checked 4026531840 words (93.8%) in 294.3s (13695687 words/sec)
checked 4160749568 words (96.9%) in 303.6s (13731847 words/sec)
decoded 1544103388 valid instructions in 312.9s
```